### PR TITLE
fix: change server.address env for fix UnknownHostException

### DIFF
--- a/conf/spring/application.example.prod.yaml
+++ b/conf/spring/application.example.prod.yaml
@@ -34,7 +34,7 @@ spring:
 
 server:
   port: 80
-  address: "https://galaxyhi4276.co"
+  address: "127.0.0.1"
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix

## What & Why
기존에 설정한 https 도메인 호스트 설정에서 에러가 발생되는 것으로 추측되어, 다시 로컬호스트 설정
<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Test Result
<!-- Please fill out the test results. -->
