### PR TITLE
feat: 게시글 API v2 생성, 수정, 삭제 기능 추가

### DIFF
--- a/src/main/java/com/frolic/sns/global/common/file/application/LocalFileManager.java
+++ b/src/main/java/com/frolic/sns/global/common/file/application/LocalFileManager.java
@@ -38,9 +38,6 @@ public class LocalFileManager implements FileManageable {
 
   private final FileRepository fileRepository;
 
-  private final UserRepository userRepository;
-  private final JwtProvider jwtProvider;
-
   @Value("${system.path.upload-images}")
   private String uploadDir;
 
@@ -49,6 +46,9 @@ public class LocalFileManager implements FileManageable {
 
   @Value("${server.port}")
   private String port;
+
+  @Value("${system.protocol}")
+  private String protocol;
 
   @PostConstruct
   public void postConstruct() throws IOException {
@@ -88,11 +88,7 @@ public class LocalFileManager implements FileManageable {
     try (InputStream inputStream = file.getInputStream()) {
       Path updateDirPath = Paths.get(uploadDir + "/" + temperedFilename);
       Files.copy(inputStream, updateDirPath, StandardCopyOption.REPLACE_EXISTING);
-      String downloadUrl = "http://" + host +
-        ":" +
-        port +
-        "/images/" +
-        temperedFilename;
+      String downloadUrl = protocol + "://" + host + ":" + port + "/images/" + temperedFilename;
       ApplicationFile applicationFile = ApplicationFile.builder()
         .addName(temperedFilename)
         .addSize(file.getSize())
@@ -102,6 +98,7 @@ public class LocalFileManager implements FileManageable {
       return FileInfo.builder()
         .addId(id)
         .addDownloadUrl(downloadUrl)
+        .addFilename(temperedFilename)
         .build();
 
     } catch (Exception ex) {

--- a/src/main/java/com/frolic/sns/global/common/file/config/FIleManagerConfiguration.java
+++ b/src/main/java/com/frolic/sns/global/common/file/config/FIleManagerConfiguration.java
@@ -17,10 +17,6 @@ import org.springframework.context.annotation.Configuration;
 public class FIleManagerConfiguration {
   private final FileRepository fileRepository;
 
-  private final UserRepository userRepository;
-
-  private final JwtProvider jwtProvider;
-
   @Value("${spring.profiles.active}")
   private String profile;
 
@@ -28,7 +24,7 @@ public class FIleManagerConfiguration {
     log.error("profile: {}", profile);
     if (profile.equals("local")) {
       log.info("파일 관리자 객체가 LocalFileManager 로 생성되었습니다.");
-      return new LocalFileManager(fileRepository, userRepository, jwtProvider);
+      return new LocalFileManager(fileRepository);
     } else {
       log.info("파일 관리자 객체가 S3FileManager 로 생성되었습니다.");
       return new S3FileManager(fileRepository);

--- a/src/main/java/com/frolic/sns/global/common/file/dto/FileInfo.java
+++ b/src/main/java/com/frolic/sns/global/common/file/dto/FileInfo.java
@@ -12,13 +12,16 @@ public class FileInfo {
 
   private final Long id;
   private final String downloadUrl;
+  private final String filename;
 
   @Builder(setterPrefix = "add")
-  public FileInfo(final Long id, final String downloadUrl) {
+  public FileInfo(final Long id, final String downloadUrl, final String filename) {
     Assert.isInstanceOf(Long.class, id, getIllegalFieldError("id"));
     Assert.hasText(downloadUrl, getIllegalFieldError("downloadUrl"));
+    Assert.hasText(filename, getIllegalFieldError("filename"));
     this.id = id;
     this.downloadUrl = downloadUrl;
+    this.filename = filename;
   }
 
 }

--- a/src/main/java/com/frolic/sns/post/api/PostCrudApi.java
+++ b/src/main/java/com/frolic/sns/post/api/PostCrudApi.java
@@ -47,12 +47,6 @@ public class PostCrudApi {
       .body(ResponseHelper.createDataMap(post));
   }
 
-  @PostMapping("/v2")
-  public ResponseEntity createPostApiV2(@Valid CreatePostRequest createPostRequest, HttpServletRequest request) {
-//    PostInfo post = postCrudManager.createPostV2(getToken(request), createPostRequest);
-    return ResponseEntity.status(HttpStatus.CREATED).body(null);
-  }
-
   @GetPostDocs
   @GetMapping("/{postId}")
   public ResponseEntity<Map<String, PostInfo>> getPostByIdApi(

--- a/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
+++ b/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
@@ -1,17 +1,15 @@
 package com.frolic.sns.post.api;
 
-import com.frolic.sns.global.common.ResponseHelper;
-import com.frolic.sns.global.common.file.application.FileManageable;
 import com.frolic.sns.global.config.security.JwtProvider;
 import com.frolic.sns.post.application.v2.PostCrudManagerV2;
 import com.frolic.sns.post.dto.v2.CreatePostRequest;
 import com.frolic.sns.post.dto.v2.PostInfo;
+import com.frolic.sns.post.dto.v2.UpdatePostRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -29,13 +27,31 @@ public class PostCrudV2Api {
 
   private final PostCrudManagerV2 postCrudManager;
   @PostMapping()
-  public ResponseEntity<Map<String, PostInfo>> createPost(
+  public ResponseEntity<Map<String, PostInfo>> createPostApi(
     @Valid @RequestBody CreatePostRequest createPostRequest,
     HttpServletRequest request
   ) {
     String token = jwtProvider.getTokenByHttpRequestHeader(request);
     PostInfo postInfo = postCrudManager.createPost(token, createPostRequest);
     return ResponseEntity.status(HttpStatus.CREATED).body(createDataMap(postInfo));
+  }
+
+  @PutMapping("/{postId}")
+  public ResponseEntity<Map<String, PostInfo>> updatePostApi(
+    HttpServletRequest request,
+    @PathVariable(name = "postId") Long postId,
+    @Valid @RequestBody UpdatePostRequest updatePostRequest
+  ) {
+    String token = jwtProvider.getTokenByHttpRequestHeader(request);
+    PostInfo updatedPostInfo = postCrudManager.updatePost(postId, token, updatePostRequest);
+    return ResponseEntity.ok(createDataMap(updatedPostInfo));
+  }
+
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<Void> deletePostApi(HttpServletRequest request, @PathVariable(name = "postId") Long postId) {
+    String token = jwtProvider.getTokenByHttpRequestHeader(request);
+    postCrudManager.deletePost(postId, token);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
 }

--- a/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
@@ -1,0 +1,59 @@
+package com.frolic.sns.post.application.v2;
+
+import com.frolic.sns.global.common.file.dto.FileInfo;
+import com.frolic.sns.global.common.file.model.ApplicationFile;
+import com.frolic.sns.post.dto.v2.CreatePostRequest;
+import com.frolic.sns.post.dto.v2.PostInfo;
+import com.frolic.sns.post.model.Post;
+import com.frolic.sns.post.model.PostFile;
+import com.frolic.sns.post.repository.PostRepository;
+import com.frolic.sns.user.dto.UserInfo;
+import com.frolic.sns.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CreatePostBusinessManager {
+
+  private final PostRepository postRepository;
+
+  public Post commitAndReturnPost(CreatePostRequest createPostRequest, User user) {
+    Post buildedPost = Post.builder()
+      .addUser(user)
+      .addTextContent(createPostRequest.getTextContent())
+      .build();
+    return postRepository.saveAndFlush(buildedPost);
+  }
+
+  public PostInfo.PostInfoBuilder getInitializedPostInfoBuilder(Post post, CreatePostRequest createPostRequest, User user) {
+    return PostInfo.builder()
+      .addId(post.getId())
+      .addHashtags(createPostRequest.getHashtags())
+      .addUserInfo(UserInfo.from(user))
+      .addTextContent(post.getTextContent())
+      .addCreatedDate(LocalDateTime.now())
+      .addUpdatedDate(LocalDateTime.now())
+      .addIsLikeUp(false)
+      .addLikeCount(0L)
+      .addComments(new ArrayList<>());
+  }
+
+  public List<FileInfo> getFileInfosFromPostFiles(List<PostFile> postFiles) {
+    return postFiles.stream().map((postFile) -> {
+          ApplicationFile file = postFile.getFile();
+          return FileInfo.builder()
+            .addId(file.getId())
+            .addDownloadUrl(file.getDownloadUrl())
+            .build();
+        }
+      )
+      .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/com/frolic/sns/post/application/v2/HashTagManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/HashTagManager.java
@@ -4,7 +4,6 @@ import com.frolic.sns.post.model.Hashtag;
 import com.frolic.sns.post.model.Post;
 import com.frolic.sns.post.model.PostHashTag;
 import com.frolic.sns.post.repository.HashtagDslRepository;
-import com.frolic.sns.post.repository.HashtagRepository;
 import com.frolic.sns.post.repository.PostHashtagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,7 +14,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HashTagManager {
 
-  private final HashtagRepository hashtagRepository;
   private final PostHashtagRepository postHashtagRepository;
   private final HashtagDslRepository hashtagDslRepository;
 

--- a/src/main/java/com/frolic/sns/post/application/v2/UpdatePostBusinessManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/UpdatePostBusinessManager.java
@@ -1,0 +1,115 @@
+package com.frolic.sns.post.application.v2;
+
+import com.frolic.sns.global.common.file.dto.FileInfo;
+import com.frolic.sns.global.common.file.model.ApplicationFile;
+import com.frolic.sns.global.common.file.repository.FileRepository;
+import com.frolic.sns.global.exception.NotFoundResourceException;
+import com.frolic.sns.post.dto.CommentInfo;
+import com.frolic.sns.post.dto.v2.PostInfo;
+import com.frolic.sns.post.model.Hashtag;
+import com.frolic.sns.post.model.Post;
+import com.frolic.sns.post.model.PostFile;
+import com.frolic.sns.post.model.PostHashTag;
+import com.frolic.sns.post.repository.*;
+import com.frolic.sns.user.dto.UserInfo;
+import com.frolic.sns.user.exception.NotPermissionException;
+import com.frolic.sns.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class UpdatePostBusinessManager {
+  private final PostHashtagRepository postHashtagRepository;
+  private final HashtagDslRepository hashtagDslRepository;
+
+  private final PostFileDslRepository postFileDslRepository;
+  private final PostFileRepository postFileRepository;
+  private final FileRepository fileRepository;
+  private final LikeRepository likeRepository;
+  private final CommentRepository commentRepository;
+
+  public void checkUserPermission(User requestUser, User postOwnedUser) {
+    boolean isSameUser = postOwnedUser.getId().equals(requestUser.getId());
+    if (!isSameUser) throw new NotPermissionException();
+  }
+
+  public void updateHashtags(Post post, List<String> hashtags) {
+    List<PostHashTag> postHashTags = hashtagDslRepository.getAllPostHashtagByPostId(post.getId());
+    List<PostHashTag> garbagePostHashtags = postHashTags.stream()
+      .filter(postHashTag -> !hashtags.contains(postHashTag.getHashtag().getName()))
+      .collect(Collectors.toList());
+    postHashtagRepository.deleteAll(garbagePostHashtags);
+    List<Hashtag> searchedHashtags = hashtagDslRepository.createHashtagsIfNotExists(hashtags);
+
+    searchedHashtags.forEach(hashtag -> {
+      if (!postHashtagRepository.existsByPostAndHashtag(post, hashtag)) {
+        PostHashTag newPostHashtag = PostHashTag.builder()
+          .addPost(post)
+          .addHashtag(hashtag)
+          .build();
+        postHashtagRepository.save(newPostHashtag);
+      }
+    });
+  }
+
+  public List<FileInfo> updateImages(Post post, List<Long> imageIds) {
+    List<Long> existsPostImageIds = postFileDslRepository.getIdsByPostId(post.getId());
+
+    List<Long> trash = existsPostImageIds.stream()
+      .filter(id -> !imageIds.contains(id))
+      .collect(Collectors.toList());
+    postFileDslRepository.removeAllByIds(trash);
+
+    List<PostFile> createdPostFiles = new ArrayList<>();
+    imageIds.forEach(imageId -> {
+      if (!postFileDslRepository.exists(post, imageId)) {
+        ApplicationFile applicationFile = fileRepository.findById(imageId).orElseThrow(NotFoundResourceException::new);
+        PostFile newPostFile = PostFile.builder().addFile(applicationFile).addPost(post).build();
+        createdPostFiles.add(newPostFile);
+      }
+    });
+
+    return postFileRepository.saveAll(createdPostFiles).stream().map(postFile -> {
+      ApplicationFile file = postFile.getFile();
+      return FileInfo.builder()
+        .addId(file.getId())
+        .addDownloadUrl(file.getDownloadUrl())
+        .addFilename(file.getName())
+        .build();
+    }).collect(Collectors.toList());
+  }
+
+  public PostInfo.PostInfoBuilder getBuilder(Post post, User user) {
+    UserInfo userInfo = UserInfo.from(user);
+    boolean isLikeUp = likeRepository.existsByPostAndUser(post, user);
+    List<CommentInfo> comments = commentRepository.findAllByPost(post)
+      .stream()
+      .map(comment ->
+          CommentInfo.builder()
+            .addId(comment.getId())
+            .addPostId(post.getId())
+            .addUserInfo(userInfo)
+            .addReplyUserId(null)
+            .addTextContent(comment.getTextContent())
+            .build()
+        )
+      .collect(Collectors.toList());
+    long likeCount = likeRepository.countAllByPost(post);
+
+    return PostInfo.builder()
+      .addId(post.getId())
+      .addTextContent(post.getTextContent())
+      .addCreatedDate(post.getCreatedDate())
+      .addUpdatedDate(post.getUpdatedDate())
+      .addIsLikeUp(isLikeUp)
+      .addLikeCount(likeCount)
+      .addUserInfo(userInfo)
+      .addComments(comments);
+  }
+
+}

--- a/src/main/java/com/frolic/sns/post/dto/v2/UpdatePostRequest.java
+++ b/src/main/java/com/frolic/sns/post/dto/v2/UpdatePostRequest.java
@@ -1,0 +1,30 @@
+package com.frolic.sns.post.dto.v2;
+
+import com.frolic.sns.global.exception.BuilderArgumentNotValidException;
+import com.frolic.sns.global.util.message.CommonMessageUtils;
+import io.jsonwebtoken.lang.Assert;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static com.frolic.sns.global.util.message.CommonMessageUtils.getIllegalFieldError;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePostRequest {
+
+  private String textContent;
+  private List<String> hashtags;
+  private List<Long> imageIds;
+
+  public UpdatePostRequest(String textContent, List<String> hashtags, List<Long> imageIds) {
+    Assert.hasText(textContent, getIllegalFieldError("textContent"));
+    Assert.notNull(hashtags, getIllegalFieldError("hashtags"));
+    Assert.notNull(imageIds, getIllegalFieldError("imageIds"));
+    this.textContent = textContent;
+    this.hashtags = hashtags;
+    this.imageIds = imageIds;
+  }
+
+}

--- a/src/main/java/com/frolic/sns/post/model/Post.java
+++ b/src/main/java/com/frolic/sns/post/model/Post.java
@@ -31,9 +31,6 @@ public class Post extends CreateAndModifiedTimeAuditEntity {
   private User user;
 
   @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
-  private final List<PostHashTag> postHashTags = new ArrayList<>();
-
-  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
   private List<ApplicationFile> applicationFiles = new ArrayList<>();
 
   @Builder(setterPrefix = "add")
@@ -58,6 +55,7 @@ public class Post extends CreateAndModifiedTimeAuditEntity {
     this.textContent = textContent;
   }
 
+  @Deprecated
   public void updateFiles(List<ApplicationFile> applicationFiles) {
     this.applicationFiles = applicationFiles;
   }

--- a/src/main/java/com/frolic/sns/post/model/PostHashTag.java
+++ b/src/main/java/com/frolic/sns/post/model/PostHashTag.java
@@ -2,11 +2,13 @@ package com.frolic.sns.post.model;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity(name = "post_hashtags")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostHashTag {
 

--- a/src/main/java/com/frolic/sns/post/repository/HashtagDslRepository.java
+++ b/src/main/java/com/frolic/sns/post/repository/HashtagDslRepository.java
@@ -1,6 +1,8 @@
 package com.frolic.sns.post.repository;
 
 import com.frolic.sns.post.model.Hashtag;
+import com.frolic.sns.post.model.PostHashTag;
+import com.frolic.sns.post.model.QPostHashTag;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.frolic.sns.post.model.QHashtag.*;
+import static com.frolic.sns.post.model.QPostHashTag.postHashTag;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,6 +26,12 @@ public class HashtagDslRepository {
       .where(hashtag.name.eq(name))
       .select(hashtag.id)
       .fetchFirst() > 0;
+  }
+
+  public List<PostHashTag> getAllPostHashtagByPostId(Long id) {
+    return queryFactory.selectFrom(postHashTag)
+      .where(postHashTag.post.id.eq(id))
+      .fetch();
   }
 
   public List<Hashtag> createHashtagsIfNotExists(List<String> tags) {

--- a/src/main/java/com/frolic/sns/post/repository/PostFileDslRepository.java
+++ b/src/main/java/com/frolic/sns/post/repository/PostFileDslRepository.java
@@ -1,10 +1,8 @@
 package com.frolic.sns.post.repository;
 
 import com.frolic.sns.global.common.file.model.ApplicationFile;
-import com.frolic.sns.global.common.file.model.QApplicationFile;
 import com.frolic.sns.post.model.Post;
 import com.frolic.sns.post.model.PostFile;
-import com.frolic.sns.post.model.QPostFile;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -22,7 +20,6 @@ public class PostFileDslRepository {
   private final JPAQueryFactory queryFactory;
   private final EntityManager entityManager;
 
-
   public List<PostFile> createPostFilesByIds(Post post, List<Long> fileIds) {
     List<ApplicationFile> files = queryFactory.selectFrom(applicationFile)
         .where(applicationFile.id.in(fileIds))
@@ -33,8 +30,35 @@ public class PostFileDslRepository {
       }
     );
     return queryFactory.selectFrom(postFile)
-      .where(postFile.id.in(fileIds))
+      .where(postFile.file.id.in(fileIds), postFile.post.id.eq(post.getId()))
       .fetch();
+  }
+
+  public List<Long> getIdsByIds(List<Long> ids) {
+    return queryFactory.select(postFile.id)
+      .where(postFile.file.id.in(ids))
+      .fetch();
+  }
+
+  public List<Long> getIdsByPostId(Long id) {
+    return queryFactory.select(postFile.id)
+      .from(postFile)
+      .where(postFile.post.id.eq(id))
+      .fetch();
+  }
+
+  public void removeAllByIds(List<Long> ids) {
+    queryFactory.delete(postFile)
+      .where(postFile.id.in(ids))
+      .execute();
+  }
+
+  public Boolean exists(Post post, Long id) {
+    Long fetchOne = queryFactory.from(postFile)
+      .where(postFile.post.id.eq(post.getId()), postFile.id.eq(id))
+      .select(postFile.id)
+      .fetchFirst();
+    return fetchOne != null;
   }
 
 }

--- a/src/main/java/com/frolic/sns/post/repository/PostFileDslRepository.java
+++ b/src/main/java/com/frolic/sns/post/repository/PostFileDslRepository.java
@@ -34,12 +34,6 @@ public class PostFileDslRepository {
       .fetch();
   }
 
-  public List<Long> getIdsByIds(List<Long> ids) {
-    return queryFactory.select(postFile.id)
-      .where(postFile.file.id.in(ids))
-      .fetch();
-  }
-
   public List<Long> getIdsByPostId(Long id) {
     return queryFactory.select(postFile.id)
       .from(postFile)
@@ -53,7 +47,7 @@ public class PostFileDslRepository {
       .execute();
   }
 
-  public Boolean exists(Post post, Long id) {
+  public boolean exists(Post post, Long id) {
     Long fetchOne = queryFactory.from(postFile)
       .where(postFile.post.id.eq(post.getId()), postFile.id.eq(id))
       .select(postFile.id)

--- a/src/main/resources/application-system.yaml
+++ b/src/main/resources/application-system.yaml
@@ -1,4 +1,5 @@
 system:
+  protocol: "http"
   twilio:
     sid: ${TWILIO_SID}
     token: ${TWILIO_TOKEN}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
**Jira Tickets** 
[issue #FL-134](https://geezers.atlassian.net/browse/FL-134)
[issue #FL-135](https://geezers.atlassian.net/browse/FL-135)

## What & Why
새로운 게시글 api (v2) 에 대해 생성, 수정, 삭제 기능을 작업하였습니다.
v2 로 코드가 다시 작성되면서 다음과 같은 이점이 추가되었습니다.
- 기존 기능보다 발생하는 쿼리가 조금 더 최적화 되었음.
- 핵심 모듈의 코드가 인간이 쉽게 인지할 수 있는 수준으로 추상화하여 가독성을 좋게 만들고, 관리하기 용이하게 바꿈
- 해당 기능부터 프로젝트 최초로 Querydsl 을 도입하여 쿼리 최적화 및 Type-Safe 한 쿼리 메서드를 작성하였음
- 기존 게시글과 해시태그 간 양방향 관계를 끊어내고 단방향을 유지하여 시스템 최적화를 일굼

<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Test Result
<!-- Please fill out the test results. -->
