### PR TITLE
fix: isLikeUp 초기화 문제로 인한 에러 현상 해결

### DIFF
--- a/src/main/java/com/frolic/sns/post/application/PostCrudManagerImpl.java
+++ b/src/main/java/com/frolic/sns/post/application/PostCrudManagerImpl.java
@@ -121,6 +121,7 @@ public class PostCrudManagerImpl implements PostCrudManager {
     postRepository.deleteById(id);
   }
 
+  @Deprecated
   @Override
   public PostInfo createPost(String token, com.frolic.sns.post.dto.CreatePostRequest createInfo, List<CustomFile> files) {
     User user = getUserIsTokenAble(token);
@@ -248,7 +249,7 @@ public class PostCrudManagerImpl implements PostCrudManager {
       .map(article -> {
         List<String> hashtags = postHashtagRepository.findAllByPost(article);
         UserInfo articleOwner = UserInfo.from(article.getUser());
-        return getSingleArticleDto(article,hashtags, articleOwner, user);
+        return getSingleArticleDto(article, hashtags, articleOwner, user);
       })
       .collect(Collectors.toList());
   }

--- a/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
@@ -55,6 +55,7 @@ public class CreatePostBusinessManager {
     return FileInfo.builder()
       .addId(file.getId())
       .addDownloadUrl(file.getDownloadUrl())
+      .addFilename(file.getName())
       .build();
   }
 

--- a/src/main/java/com/frolic/sns/post/application/v2/HashTagManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/HashTagManager.java
@@ -19,6 +19,7 @@ public class HashTagManager {
 
   protected void connectHashtagsWithPost(List<String> hashtags, Post post) {
     List<Hashtag> entities = hashtagDslRepository.createHashtagsIfNotExists(hashtags);
+    if (entities == null) return;
     entities.forEach(entity -> {
       boolean isAlreadyExistsRelation = postHashtagRepository.existsByPostAndHashtag(post, entity);
       if (!isAlreadyExistsRelation) {

--- a/src/main/java/com/frolic/sns/post/dto/PostInfo.java
+++ b/src/main/java/com/frolic/sns/post/dto/PostInfo.java
@@ -42,7 +42,6 @@ public class PostInfo {
     Assert.isInstanceOf(List.class, comments, getIllegalFieldError("comments"));
     Assert.isInstanceOf(List.class, hashtags, getIllegalFieldError("hashtags"));
     Assert.isInstanceOf(Long.class, likeCount, getIllegalFieldError("likeCount"));
-    Assert.isInstanceOf(boolean.class, isLikeUp, getIllegalFieldError("isLikeUp"));
     Assert.isInstanceOf(List.class, fileDownloadUrls, getIllegalFieldError("fileDownloadUrls"));
     Assert.isInstanceOf(LocalDateTime.class, createdDate, getIllegalFieldError("createdDate"));
     Assert.isInstanceOf(LocalDateTime.class, updatedDate, getIllegalFieldError("updatedDate"));

--- a/src/main/java/com/frolic/sns/post/dto/v2/CreatePostRequest.java
+++ b/src/main/java/com/frolic/sns/post/dto/v2/CreatePostRequest.java
@@ -28,6 +28,7 @@ public class CreatePostRequest {
     List<Long> imageIds
   ) {
     Assert.hasText(textContent, getIllegalFieldError("textContent"));
+    Assert.notNull(hashtags, getIllegalFieldError("hashtags"));
     this.textContent = textContent;
     this.hashtags = hashtags;
     this.imageIds = imageIds;

--- a/src/main/java/com/frolic/sns/post/dto/v2/PostInfo.java
+++ b/src/main/java/com/frolic/sns/post/dto/v2/PostInfo.java
@@ -43,7 +43,6 @@ public class PostInfo {
     Assert.isInstanceOf(String.class, textContent, getIllegalFieldError("textContent"));
     Assert.isInstanceOf(UserInfo.class, userInfo, getIllegalFieldError("userInfo"));
     Assert.isInstanceOf(List.class, comments, getIllegalFieldError("comments"));
-    Assert.isInstanceOf(List.class, hashtags, getIllegalFieldError("hashtags"));
     Assert.isInstanceOf(Long.class, likeCount, getIllegalFieldError("likeCount"));
     Assert.notNull(files, getIllegalFieldError("fileDownloadUrls"));
     Assert.isInstanceOf(LocalDateTime.class, createdDate, getIllegalFieldError("createdDate"));

--- a/src/main/java/com/frolic/sns/post/repository/HashtagDslRepository.java
+++ b/src/main/java/com/frolic/sns/post/repository/HashtagDslRepository.java
@@ -35,6 +35,7 @@ public class HashtagDslRepository {
   }
 
   public List<Hashtag> createHashtagsIfNotExists(List<String> tags) {
+    if (tags == null) return null;
     List<String> exists = queryFactory
       .select(hashtag.name)
       .from(hashtag)


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix

## What & Why
isLikeUp 프로퍼티 초기화 문제로 인한 정상 응답이 발생하지 못하는 에러 해결하였습니다.
또한 클라이언트 hashtags 값이 null 로 설정된 부분에 맞추어 hashtags prop nullable 처리 코드를 작성하였습니다.
<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Test Result
<!-- Please fill out the test results. -->
