### PR TITLE
fix: 파일 검증 기능 테스트 작성 및 버그 수정

### DIFF
--- a/src/main/java/com/frolic/sns/global/common/file/application/FileExtensionValidator.java
+++ b/src/main/java/com/frolic/sns/global/common/file/application/FileExtensionValidator.java
@@ -4,7 +4,12 @@ import com.frolic.sns.global.common.file.exception.FaultFileExtensionException;
 import com.frolic.sns.global.common.file.exception.FaultFilenameException;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
+import java.util.List;
+
 public interface FileExtensionValidator {
+
+  List<String> imageExtensionNameList = Arrays.asList("jpg", "jpeg", "png", "gif", "bmp", "svg", "webp");
 
   default String getExtensionName(MultipartFile file) {
     String filename = file.getOriginalFilename();
@@ -13,7 +18,7 @@ public interface FileExtensionValidator {
     int extIndex = file.getOriginalFilename().indexOf(".");
     if (extIndex == -1) throw new FaultFileExtensionException();
 
-    return file.getOriginalFilename().substring(extIndex);
+    return file.getOriginalFilename().substring(extIndex).substring(1);
   }
 
 }

--- a/src/main/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidator.java
+++ b/src/main/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidator.java
@@ -5,18 +5,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Arrays;
-import java.util.List;
-
 @Component
 public final class ImageFileExtensionValidator implements FileExtensionValidator {
-
-  private final List<String> extensionNameList = Arrays.asList("jpg", "jpeg", "png", "gif", "bmp", "svg", "webp");
 
   public void validate(MultipartFile file) {
     if (file == null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "요청 파일 형식이 잘못되었습니다.");
     String extensionName = getExtensionName(file);
-    if (!extensionNameList.contains(extensionName)) {
+    if (!imageExtensionNameList.contains(extensionName)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지 파일 확장자가 아닙니다.");
     }
   }

--- a/src/test/java/com/frolic/sns/auth/application/finder/EmailFindManagerTest.java
+++ b/src/test/java/com/frolic/sns/auth/application/finder/EmailFindManagerTest.java
@@ -61,7 +61,7 @@ class EmailFindManagerTest {
     VerifyCodeRequest request = new VerifyCodeRequest("wrongCode");
 
     // then
-    assertThrows(MisMatchAuthCodeException.class, () -> emailFindManager.authCodeVerify(id, request));
+    assertThrows(MisMatchAuthCodeException.class, () -> emailFindManager.verifyAuthCode(id, request));
   }
 
   @Test
@@ -73,12 +73,12 @@ class EmailFindManagerTest {
     // when
     for (int i = 0; i < 5; i++) {
       assertThrows(MisMatchAuthCodeException.class, () -> {
-        emailFindManager.authCodeVerify(id, request);
+        emailFindManager.verifyAuthCode(id, request);
       });
     }
 
     // then
-    assertThrows(OverTriedAuthCodeException.class, () -> emailFindManager.authCodeVerify(id, request));
+    assertThrows(OverTriedAuthCodeException.class, () -> emailFindManager.verifyAuthCode(id, request));
   }
 
 }

--- a/src/test/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidatorTest.java
+++ b/src/test/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidatorTest.java
@@ -1,0 +1,36 @@
+package com.frolic.sns.global.common.file.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImageFileExtensionValidatorTest {
+
+  private final ImageFileExtensionValidator imageFileExtensionValidator = new ImageFileExtensionValidator();
+
+  @Test
+  @DisplayName("이미지 파일이 아니라면 예외가 발생한다.")
+  void invalidFileExtension() {
+    // given
+    MockMultipartFile mockMultipartFile = new MockMultipartFile("test.exe", "test.exe", "image", "hello".getBytes());
+
+    // when, then
+    assertThrows(ResponseStatusException.class, () -> {
+      imageFileExtensionValidator.validate(mockMultipartFile);
+    });
+  }
+
+  @Test
+  @DisplayName("이미지 파일이 정상 검수된다.")
+  void validFileExtension() {
+    // given
+    MockMultipartFile mockMultipartFile = new MockMultipartFile("test.svg", "test.svg", "image", "hello".getBytes());
+
+    // when, then
+    imageFileExtensionValidator.validate(mockMultipartFile);
+  }
+
+}

--- a/src/test/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidatorTest.java
+++ b/src/test/java/com/frolic/sns/global/common/file/application/ImageFileExtensionValidatorTest.java
@@ -30,7 +30,7 @@ class ImageFileExtensionValidatorTest {
     MockMultipartFile mockMultipartFile = new MockMultipartFile("test.svg", "test.svg", "image", "hello".getBytes());
 
     // when, then
-    imageFileExtensionValidator.validate(mockMultipartFile);
+    assertDoesNotThrow(() -> imageFileExtensionValidator.validate(mockMultipartFile));
   }
 
 }

--- a/src/test/java/com/frolic/sns/global/common/file/application/LocalApplicationFileServiceTestDeprecated.java
+++ b/src/test/java/com/frolic/sns/global/common/file/application/LocalApplicationFileServiceTestDeprecated.java
@@ -28,7 +28,7 @@ class LocalApplicationFileServiceTestDeprecated {
       MediaType.TEXT_PLAIN_VALUE,
       fileContentBytes
     );
-    assertThrows(FaultFileExtensionException.class, () -> localFileManager.singleUpload(file));
+    assertThrows(FaultFileExtensionException.class, () -> localFileManager.uploadSingleFile(file));
   }
 
 //  @Test


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
* 파일 확장자에 대한 검증을 수행하는 클래스의 기능에 대한 테스트를 작성하였습니다.
* 기존 이미지 확장자 업로드에 대해 잘못된 검증을 수행하는 로직을 수정하였습니다.
<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Test Result
![image](https://user-images.githubusercontent.com/50310464/224529125-ebb0c44a-f91e-4b3b-8fcf-658712099977.png)

<!-- Please fill out the test results. -->
