### PR TITLE
feat: 게시글 불러오기 관련 api 모두 작성 ( docs 포함 ) [depends on #54]

### DIFF
--- a/src/main/java/com/frolic/sns/post/api/GetPostApi.java
+++ b/src/main/java/com/frolic/sns/post/api/GetPostApi.java
@@ -1,0 +1,59 @@
+package com.frolic.sns.post.api;
+
+import com.frolic.sns.post.application.GetPostService;
+import com.frolic.sns.post.application.v2.PostCrudManagerV2;
+import com.frolic.sns.post.dto.v2.GetPostCursorRequest;
+import com.frolic.sns.post.dto.v2.PostInfo;
+import com.frolic.sns.post.swagger.GetPostListDocs;
+import com.frolic.sns.post.swagger.GetPostsByHashtagsDocs;
+import com.frolic.sns.post.swagger.GetUserPostsDocs;
+import com.frolic.sns.user.application.UserManager;
+import com.frolic.sns.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+
+import static com.frolic.sns.global.common.ResponseHelper.createDataMap;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class GetPostApi {
+
+  private final UserManager userManager;
+  private final PostCrudManagerV2 postCrudManager;
+  private final GetPostService getPostService;
+
+  @GetPostListDocs
+  @PostMapping("/list")
+  public ResponseEntity<Map<String, List<PostInfo>>> getPostsApi(@RequestBody GetPostCursorRequest getPostCursorRequest) {
+    List<PostInfo> postInfos = postCrudManager.getPosts(getPostCursorRequest);
+    return ResponseEntity.ok(createDataMap(postInfos));
+  }
+
+  @GetUserPostsDocs
+  @PostMapping("list/user")
+  public ResponseEntity<Map<String, List<PostInfo>>> getUserPostsApi(
+    HttpServletRequest request,
+    @RequestBody GetPostCursorRequest getPostCursorRequest
+  ) {
+    User user = userManager.getUserByHttpRequest(request);
+    List<PostInfo> postInfos = getPostService.getPostsOwnedByUser(user, getPostCursorRequest);
+    return ResponseEntity.ok(createDataMap(postInfos));
+  }
+
+  @GetPostsByHashtagsDocs
+  @PostMapping("/list/search")
+  public ResponseEntity<Map<String, List<PostInfo>>> getPostsByHashtagsApi(
+    @RequestParam List<String> hashtags,
+    @RequestBody GetPostCursorRequest getPostCursorRequest
+  ) {
+    List<PostInfo> postInfos = getPostService.getPostsByHashtags(hashtags, getPostCursorRequest);
+    return ResponseEntity.ok(createDataMap(postInfos));
+  }
+
+}

--- a/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
+++ b/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
@@ -8,11 +8,11 @@ import com.frolic.sns.post.dto.v2.PostInfo;
 import com.frolic.sns.post.dto.v2.UpdatePostRequest;
 import com.frolic.sns.post.swagger.CreatePostDocs;
 import com.frolic.sns.post.swagger.DeletePostDocs;
+import com.frolic.sns.post.swagger.GetPostListDocs;
 import com.frolic.sns.post.swagger.UpdatePostDocs;
 import com.frolic.sns.user.application.UserManager;
 import com.frolic.sns.user.model.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import static com.frolic.sns.global.common.ResponseHelper.createDataMap;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/posts")
@@ -34,6 +33,7 @@ public class PostCrudV2Api {
 
   private final PostCrudManagerV2 postCrudManager;
 
+  @GetPostListDocs
   @PostMapping("/list")
   public ResponseEntity<Map<String, List<PostInfo>>> getPostsApi(
     HttpServletRequest request,
@@ -41,7 +41,7 @@ public class PostCrudV2Api {
   ) {
     User user = userManager.getUserByHttpRequest(request);
     List<PostInfo> PostInfos = postCrudManager.getPosts(getPostCursorRequest, user);
-    return ResponseEntity.ok(ResponseHelper.createDataMap(PostInfos));
+    return ResponseEntity.ok(createDataMap(PostInfos));
   }
 
   @CreatePostDocs

--- a/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
+++ b/src/main/java/com/frolic/sns/post/api/PostCrudV2Api.java
@@ -8,7 +8,6 @@ import com.frolic.sns.post.dto.v2.PostInfo;
 import com.frolic.sns.post.dto.v2.UpdatePostRequest;
 import com.frolic.sns.post.swagger.CreatePostDocs;
 import com.frolic.sns.post.swagger.DeletePostDocs;
-import com.frolic.sns.post.swagger.GetPostListDocs;
 import com.frolic.sns.post.swagger.UpdatePostDocs;
 import com.frolic.sns.user.application.UserManager;
 import com.frolic.sns.user.model.User;
@@ -19,30 +18,17 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.util.List;
 import java.util.Map;
 
 import static com.frolic.sns.global.common.ResponseHelper.createDataMap;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v2/posts")
+@RequestMapping("/api/posts")
 public class PostCrudV2Api {
 
   private final UserManager userManager;
-
   private final PostCrudManagerV2 postCrudManager;
-
-  @GetPostListDocs
-  @PostMapping("/list")
-  public ResponseEntity<Map<String, List<PostInfo>>> getPostsApi(
-    HttpServletRequest request,
-    @RequestBody GetPostCursorRequest getPostCursorRequest
-  ) {
-    User user = userManager.getUserByHttpRequest(request);
-    List<PostInfo> PostInfos = postCrudManager.getPosts(getPostCursorRequest, user);
-    return ResponseEntity.ok(createDataMap(PostInfos));
-  }
 
   @CreatePostDocs
   @PostMapping

--- a/src/main/java/com/frolic/sns/post/api/PostLikeApi.java
+++ b/src/main/java/com/frolic/sns/post/api/PostLikeApi.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/posts")
+@RequestMapping("/api/posts/like")
 public class PostLikeApi {
 
   private final JwtProvider jwtProvider;
@@ -23,7 +23,7 @@ public class PostLikeApi {
 
 
   @PostLikeDocs
-  @GetMapping("/like")
+  @GetMapping
   public ResponseEntity<Map<String, Long>> likeApi(
     HttpServletRequest request,
     @RequestParam(name = "postId") Long postId
@@ -36,7 +36,7 @@ public class PostLikeApi {
   }
 
   @PostDisLikeDocs
-  @DeleteMapping("/like")
+  @DeleteMapping
   public ResponseEntity<Map<String, Long>> unLikeApi(
     HttpServletRequest request,
     @RequestParam(name = "postId") Long postId

--- a/src/main/java/com/frolic/sns/post/application/GetPostService.java
+++ b/src/main/java/com/frolic/sns/post/application/GetPostService.java
@@ -1,0 +1,31 @@
+package com.frolic.sns.post.application;
+
+import com.frolic.sns.post.application.v2.GetPostBusinessManager;
+import com.frolic.sns.post.dto.v2.GetPostCursorRequest;
+import com.frolic.sns.post.dto.v2.PostInfo;
+import com.frolic.sns.post.model.Post;
+import com.frolic.sns.post.repository.PostDslRespository;
+import com.frolic.sns.user.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetPostService {
+
+  private final PostDslRespository postDslRespository;
+  private final GetPostBusinessManager getPostBusinessManager;
+
+  public List<PostInfo> getPostsOwnedByUser(User user, GetPostCursorRequest getPostCursorRequest) {
+    List<Post> posts = postDslRespository.findPostByUser(getPostCursorRequest.getCursorId(), user.getId());
+    return getPostBusinessManager.createPostInfos(posts);
+  }
+
+  public List<PostInfo> getPostsByHashtags(List<String> hashtags, GetPostCursorRequest getPostCursorRequest) {
+    List<Post> posts = postDslRespository.findPostByHashtags(getPostCursorRequest.getCursorId(), hashtags);
+    return getPostBusinessManager.createPostInfos(posts);
+  }
+
+}

--- a/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/CreatePostBusinessManager.java
@@ -53,6 +53,7 @@ public class CreatePostBusinessManager {
     ApplicationFile file = postFile.getFile();
     return FileInfo.builder()
       .addId(file.getId())
+      .addFilename(file.getName())
       .build();
   }
 

--- a/src/main/java/com/frolic/sns/post/application/v2/GetPostBusinessManager.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/GetPostBusinessManager.java
@@ -4,7 +4,6 @@ import com.frolic.sns.post.dto.v2.PostInfo;
 import com.frolic.sns.post.model.Post;
 import com.frolic.sns.post.repository.*;
 import com.frolic.sns.user.dto.UserInfo;
-import com.frolic.sns.user.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,15 +17,15 @@ public class GetPostBusinessManager {
   private final LikeRepository likeRepository;
   private final CommentDslRepository commentDslRepository;
 
-  public List<PostInfo> createPostInfos(List<Post> posts, User user) {
+  public List<PostInfo> createPostInfos(List<Post> posts) {
     return posts.stream().map(
       post -> PostInfo.addProperties(post)
         .addCommentCount(
           commentDslRepository.getCommentCount(post.getId())
         )
         .addLikeCount(likeRepository.countAllByPost(post))
-        .addIsLikeUp(likeRepository.existsByPostAndUser(post, user))
-        .addUserInfo(UserInfo.from(user))
+        .addIsLikeUp(likeRepository.existsByPostAndUser(post, post.getUser()))
+        .addUserInfo(UserInfo.from(post.getUser()))
         .build()
     )
       .collect(Collectors.toList());

--- a/src/main/java/com/frolic/sns/post/application/v2/PostCrudManagerV2.java
+++ b/src/main/java/com/frolic/sns/post/application/v2/PostCrudManagerV2.java
@@ -33,14 +33,10 @@ public class PostCrudManagerV2 {
   private final UpdatePostBusinessManager updatePostBusinessManager;
 
 
-  public List<PostInfo> getPosts(GetPostCursorRequest postCursorRequest, User user) {
-    List<Post> posts;
+  public List<PostInfo> getPosts(GetPostCursorRequest postCursorRequest) {
     Long cursorId = postCursorRequest.getCursorId();
-    if (postCursorRequest.getCursorId() == null)
-      posts = postDslRespository.findPosts();
-    else
-      posts = postDslRespository.findPostsByCursorId(cursorId);
-    return getPostBusinessManager.createPostInfos(posts, user);
+    List<Post> posts = postDslRespository.findPosts(cursorId);
+    return getPostBusinessManager.createPostInfos(posts);
   }
 
   public PostInfo createPost(User user, CreatePostRequest createPostRequest) {

--- a/src/main/java/com/frolic/sns/post/dto/v2/CreatePostRequest.java
+++ b/src/main/java/com/frolic/sns/post/dto/v2/CreatePostRequest.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
-import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 import static com.frolic.sns.global.util.message.CommonMessageUtils.getIllegalFieldError;
@@ -14,11 +15,13 @@ import static com.frolic.sns.global.util.message.CommonMessageUtils.getIllegalFi
 @NoArgsConstructor
 public class CreatePostRequest {
 
-//  @Max(value = 150, message = "게시글 본문은 150 글자 이하여야 합니다.")
+  @Size(max = 140, message = "게시글 본문은 140글자 이하여야 합니다.")
   private String textContent;
 
+  @NotNull(message = "hashtags 값이 null 이어서는 안됩니다.")
   private List<String> hashtags;
 
+  @NotNull(message = "imageIds 값이 null 이어서는 안됩니다.")
   private List<Long> imageIds;
 
   @Builder(setterPrefix = "add")

--- a/src/main/java/com/frolic/sns/post/dto/v2/PostInfo.java
+++ b/src/main/java/com/frolic/sns/post/dto/v2/PostInfo.java
@@ -12,7 +12,9 @@ import lombok.Getter;
 import org.springframework.util.Assert;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.frolic.sns.global.util.message.CommonMessageUtils.getIllegalFieldError;
@@ -57,7 +59,7 @@ public class PostInfo {
     this.textContent = textContent;
     this.userInfo = userInfo;
     this.commentCount = commentCount;
-    this.hashtags = hashtags;
+    this.hashtags = Objects.requireNonNullElseGet(hashtags, ArrayList::new);
     this.likeCount = likeCount;
     this.isLikeUp = isLikeUp;
     this.files = files;

--- a/src/main/java/com/frolic/sns/post/model/Post.java
+++ b/src/main/java/com/frolic/sns/post/model/Post.java
@@ -36,10 +36,7 @@ public class Post extends CreateAndModifiedTimeAuditEntity {
   private final List<PostHashTag> postHashTags = new ArrayList<>();
 
   @Builder(setterPrefix = "add")
-  public Post(
-    String textContent,
-    User user
-  ) {
+  public Post(String textContent, User user) {
     this.textContent = textContent;
     this.user = user;
   }

--- a/src/main/java/com/frolic/sns/post/repository/PostDslRespository.java
+++ b/src/main/java/com/frolic/sns/post/repository/PostDslRespository.java
@@ -1,7 +1,10 @@
 package com.frolic.sns.post.repository;
 
 import com.frolic.sns.post.model.Post;
+import com.frolic.sns.post.model.QPostHashTag;
+import com.frolic.sns.user.model.User;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -19,18 +22,35 @@ public class PostDslRespository {
 
   private final JPAQueryFactory queryFactory;
 
-  public List<Post> findPosts() {
-    return queryFactory.selectFrom(post)
+  private JPAQuery<Post> createQueryTemplate(Long cursorId) {
+    JPAQuery<Post> query = queryFactory.selectFrom(post);
+
+    if (cursorId != null) {
+      query.where(post.id.lt(cursorId));
+    }
+
+    query
       .orderBy(post.createdDate.desc())
-      .limit(10)
+      .limit(10);
+
+    return query;
+  }
+
+  public List<Post> findPosts(Long cursorId) {
+    return createQueryTemplate(cursorId).fetch();
+  }
+
+  public List<Post> findPostByUser(Long cursorId, Long userId) {
+    return createQueryTemplate(cursorId)
+      .where(post.user.id.eq(userId))
       .fetch();
   }
 
-  public List<Post> findPostsByCursorId(Long cursorId) {
-    return queryFactory.selectFrom(post)
-      .where(post.id.lt(cursorId))
-      .orderBy(post.createdDate.desc())
-      .limit(10)
+  public List<Post> findPostByHashtags(Long cursorId, List<String> hashtags) {
+    return createQueryTemplate(cursorId)
+      .join(postHashTag)
+      .on(postHashTag.post.eq(post))
+      .where(postHashTag.hashtag.name.in(hashtags))
       .fetch();
   }
 

--- a/src/main/java/com/frolic/sns/post/swagger/GetPostListDocs.java
+++ b/src/main/java/com/frolic/sns/post/swagger/GetPostListDocs.java
@@ -1,0 +1,28 @@
+package com.frolic.sns.post.swagger;
+
+import com.frolic.sns.global.swagger.CommonAuthError;
+import com.frolic.sns.global.swagger.SwaggerMessageUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.*;
+
+@Operation(
+  summary = "게시글 리스트 불러오기 API",
+  description = "cursorId 값 기반으로 게시글 리스트를 불러옵니다.",
+  tags = SwaggerMessageUtils.ArticleManagementApi,
+  responses = {
+    @ApiResponse(
+      responseCode = "200",
+      description = "게시글을 성공적으로 불러옵니다.",
+      content = @Content(schema = @Schema(implementation = PostSchemas.GetPostListSchema.class))
+    )
+  }
+)
+@CommonAuthError
+@Target(ElementType.METHOD)
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GetPostListDocs { }

--- a/src/main/java/com/frolic/sns/post/swagger/GetPostsByHashtagsDocs.java
+++ b/src/main/java/com/frolic/sns/post/swagger/GetPostsByHashtagsDocs.java
@@ -1,0 +1,28 @@
+package com.frolic.sns.post.swagger;
+
+import com.frolic.sns.global.swagger.CommonAuthError;
+import com.frolic.sns.global.swagger.SwaggerMessageUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.*;
+
+@Operation(
+  summary = "해시태그 검색 기반 게시글 불러오기 API",
+  description = "해시태그 리스트와 cursorId 값 기반으로 게시글을 불러옵니다.",
+  tags = SwaggerMessageUtils.ArticleManagementApi,
+  responses = {
+    @ApiResponse(
+      responseCode = "200",
+      description = "게시글을 성공적으로 불러옵니다.",
+      content = @Content(schema = @Schema(implementation = PostSchemas.GetPostListSchema.class))
+    )
+  }
+)
+@CommonAuthError
+@Target(ElementType.METHOD)
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GetPostsByHashtagsDocs { }

--- a/src/main/java/com/frolic/sns/post/swagger/GetUserPostsDocs.java
+++ b/src/main/java/com/frolic/sns/post/swagger/GetUserPostsDocs.java
@@ -1,0 +1,28 @@
+package com.frolic.sns.post.swagger;
+
+import com.frolic.sns.global.swagger.CommonAuthError;
+import com.frolic.sns.global.swagger.SwaggerMessageUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.*;
+
+@Operation(
+  summary = "사용자 게시글 리스트 불러오기 API",
+  description = "cursorId 값 기반으로 요청 사용자의 게시글 리스트를 불러옵니다.",
+  tags = SwaggerMessageUtils.ArticleManagementApi,
+  responses = {
+    @ApiResponse(
+      responseCode = "200",
+      description = "게시글을 성공적으로 불러옵니다.",
+      content = @Content(schema = @Schema(implementation = PostSchemas.GetPostListSchema.class))
+    )
+  }
+)
+@CommonAuthError
+@Target(ElementType.METHOD)
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GetUserPostsDocs { }

--- a/src/main/java/com/frolic/sns/post/swagger/PostSchemas.java
+++ b/src/main/java/com/frolic/sns/post/swagger/PostSchemas.java
@@ -8,6 +8,11 @@ import java.util.List;
 public class PostSchemas {
 
   @Getter
+  public static class GetPostListSchema {
+    List<PostInfo> data;
+  }
+
+  @Getter
   public static class CreateArticleSchema {
     PostInfo data;
   }


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
**Jira Tickets** 
[#155](https://geezers.atlassian.net/browse/FL-155)

## What & Why

### 현재 작업은 #54 에 의존하고 있습니다.

* 기존에 존재하던 api 들이 재작성되었습니다.
* page, size 값으로 전달받던 페이지네이션 정보를 cursorId 값 기반으로 변경되었으며, 엔드포인트 url 수정이 있습니다.
* 자세한 양식은 swagger docs 확인해주세요.
* 다음과 같은 사유로 엔드포인트에 버전을 표기하던 내용을 제거하였습니다.
  * 기존 v1 기능을 서비스하고있는 대상이 없음
  * 처음 설계부터 버전 기능을 고려하지 않았음 

> /api/posts/v2/**/* --> /api/posts/**/*

> [GET] /api/posts/list/token?{params} --> [POST] /api/post/list/user

> [GET] /api/posts/search?{params} --> [POST] /api/posts/search?{params}


![image](https://user-images.githubusercontent.com/50310464/225195169-41c92eb1-8b8a-4e3f-bc1d-f64089313b7f.png)

<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Test Result
<!-- Please fill out the test results. -->
